### PR TITLE
Add arm64 build tag

### DIFF
--- a/basic_native.go
+++ b/basic_native.go
@@ -1,4 +1,4 @@
-// +build 386, arm, amd64
+//go:build 386 || amd64 || arm || arm64
 
 package binp
 

--- a/binprinter_native_le.go
+++ b/binprinter_native_le.go
@@ -1,4 +1,4 @@
-// +build 386 amd64 arm
+//go:build 386 || amd64 || arm || arm64
 
 package binp
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/taruti/binp
+
+go 1.22.8


### PR DESCRIPTION
We have a build that relies on this package and started failing for builds on Apple Silicon because it needs the tag `arm64`